### PR TITLE
Made code analysers private

### DIFF
--- a/SafeParallelAsync.sln
+++ b/SafeParallelAsync.sln
@@ -25,8 +25,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleUse", "examples\Simpl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdvancedUse", "examples\AdvancedUse\AdvancedUse.csproj", "{BEBBB29B-DC88-46DE-84E8-9267C808419C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test", "examples\test\test.csproj", "{35C328B9-FFF6-49C0-A1C8-5B37F425FF78}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,10 +51,6 @@ Global
 		{BEBBB29B-DC88-46DE-84E8-9267C808419C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BEBBB29B-DC88-46DE-84E8-9267C808419C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BEBBB29B-DC88-46DE-84E8-9267C808419C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{35C328B9-FFF6-49C0-A1C8-5B37F425FF78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{35C328B9-FFF6-49C0-A1C8-5B37F425FF78}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{35C328B9-FFF6-49C0-A1C8-5B37F425FF78}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{35C328B9-FFF6-49C0-A1C8-5B37F425FF78}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,7 +59,6 @@ Global
 		{81D533F5-D78A-4B44-8921-26D8A9E11A6F} = {8581F86A-97E7-4B79-9AD7-E24F3FB04CEC}
 		{55DBA2B1-EB3A-4CAD-B841-77D0F0797FA3} = {893E7FDF-775E-451B-B381-FB9F6BE014E7}
 		{BEBBB29B-DC88-46DE-84E8-9267C808419C} = {893E7FDF-775E-451B-B381-FB9F6BE014E7}
-		{35C328B9-FFF6-49C0-A1C8-5B37F425FF78} = {893E7FDF-775E-451B-B381-FB9F6BE014E7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5865C007-F066-49A8-8A7D-6A609D17B3A1}

--- a/src/SafeParallelAsync/SafeParallelAsync.csproj
+++ b/src/SafeParallelAsync/SafeParallelAsync.csproj
@@ -6,14 +6,14 @@
     <PackageTags>Linq IEnumerable IAsyncEnumerable Async Task</PackageTags>
     <AssemblyTitle>SafeParallelAsync</AssemblyTitle>
     <Company>NewOrbit Ltd</Company>
-    <Copyright>Copyright NewOrbit Ltd 2020</Copyright>
+    <Copyright>Copyright NewOrbit Ltd 2022</Copyright>
     <Authors>FLytzen</Authors>
     <Description>This is a micro library that solves a single problem: How to run a large number of async tasks in parallel without running too many at the same time - and without running out of memory.</Description>
     <PackageProjectUrl>https://github.com/NewOrbit/SafeParallelAsync</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NewOrbit/SafeParallelAsync</RepositoryUrl>
-    <PackageReleaseNotes>Max Parallelism can now be (optionally) specified globally</PackageReleaseNotes>
+    <PackageReleaseNotes>Made the code analysis packages and stylecop private to avoid polluting the calling project.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Nullable>enable</Nullable>
     <!-- For local/debug builds -->
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tests/SafeParallelAsync.Tests/SafeParallelAsync.Tests.csproj
+++ b/tests/SafeParallelAsync.Tests/SafeParallelAsync.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Authors>NewOrbit Ltd</Authors>
     <Company>NewOrbit Ltd</Company>
     <Copyright>NewOrbit Ltd 2020</Copyright>


### PR DESCRIPTION
Fixes #10 

The package uses code analysers but had neglected to set them to "private" so they affect the calling project unintentionally.